### PR TITLE
suggest code review changes

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,22 @@
+package fairymqgo
+
+import "time"
+
+type options struct {
+	attempts    uint
+	readTimeout time.Duration
+}
+
+type Option func(*options)
+
+func WithAttempts(attempts uint) Option {
+	return func(o *options) {
+		o.attempts = attempts
+	}
+}
+
+func WithReadTimeout(t time.Duration) Option {
+	return func(o *options) {
+		o.readTimeout = t
+	}
+}

--- a/wire.go
+++ b/wire.go
@@ -1,0 +1,21 @@
+package fairymqgo
+
+type opCode string
+
+const (
+	enqueueOpCode         = opCode("ENQUEUE\r\n%d\r\n%s")
+	enqueueWithKeyOpCode  = opCode("ENQUEUE %s\r\n%d\r\n%s")
+	lenghOpCode           = opCode("LENGTH\r\n")
+	firstInOpCode         = opCode("FIRST IN\r\n")
+	messagesByKeyOpCode   = opCode("MSGS WITH KEY %s\r\n")
+	expireMsgOpCode       = opCode("EXP MSGS %d\r\n")
+	expiresSecsMsgOpCode  = opCode("EXP MSGS SEC %d\r\n")
+	shiftOpCode           = opCode("SHIFT\r\n")
+	clearOpCode           = opCode("CLEAR\r\n")
+	popOpCode             = opCode("POP\r\n")
+	lastInOpCode          = opCode("LAST IN\r\n")
+	listConsumersOpCode   = opCode("LIST CONSUMERS\r\n")
+	newConsumerOpCode     = opCode("NEW CONSUMER %s\r\n")
+	removeConsumerpOpCode = opCode("REM CONSUMER %s\r\n")
+	ackOpcode             = opCode("ACK")
+)


### PR DESCRIPTION
**What I rewrote**:
1. Made `Client` fields unexported;
2. Changed `goto` to simple `for` loop that is more readable;
3. Moved write/read flow to a separate method, which was previously repeated for each command;
4. Replaced `Configure` with the `Dial` method, which remove _temporal coupling_ and it's the only way to create a client, which makes the code more obvious;
5. Combined the commands under the `opCode` type and put them into constants, which makes discover the protocol much easier;
6. Improved error formatting;
7. `Close` now return an `error` and implements `io.Closer`;
8. Introduced `options` pattern to easily evolve client in the future.

**What I didn't do**:
1. I didn't change the tests. 

**What can be improved**:
1. Remove rsa encryption, it is unnecessary and inefficient, use SASL authentication for example;
2. Move to `grpc` for example - it's an easier way to generate new clients for any languages you want;
3. Or rewrite your text protocol to a binary one and you can achieve some benefits:
  3.1. Compactness;
  3.2. Extensibility by introducing versions (https://kafka.apache.org/protocol.html#protocol_messages);
  3.3. Type-safety: now you can use just strings, with binary protocol (or `grpc`) you could use `int32`, `int8`, `uint64`, `slices`, `maps` and so son.
4. You can make the protocol truly asynchronous. Now your client is not thread safe, because two goroutines can send request to server and get the not the response which they want, but the response which is intended for another goroutine. To get rid of this problem, you can synchronise all methods using mutexes, but then you lose the benefits of parallelism. Use some packet identifier as [kafka](https://kafka.apache.org/protocol.html#protocol_messages), [mongodb](https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/#standard-message-header), [zookeeper](https://github.com/ceache/zab_dissector/blob/master/zab.lua#L134) and many others do.